### PR TITLE
Replace `onload` with `addEventListener`

### DIFF
--- a/src/tweet-embed.tsx
+++ b/src/tweet-embed.tsx
@@ -8,7 +8,7 @@ function addScript(src: string, cb: () => any) {
     callbacks.push(cb)
     var s = document.createElement('script')
     s.setAttribute('src', src)
-    s.onload = () => callbacks.forEach((cb) => cb())
+    s.addEventListener('load', () => callbacks.forEach((cb) => cb()), false)
     document.body.appendChild(s)
   } else {
     callbacks.push(cb)


### PR DESCRIPTION
We're seeing the following errors on [zeit.co/solutions/vue](https://zeit.co/solutions/vue), where we're using this component:
```
TypeError
Cannot read property 'ready' of undefined
```

I believe this is happening because the "onload" event is fired before the script is evaluated, see https://stackoverflow.com/questions/16805043/why-is-script-onload-not-working-in-a-chrome-userscript.

This PR is an attempt to fix it.